### PR TITLE
Update dependencies and refine caching logic in shareLink service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "zod": "^4.0.17"
       },
       "devDependencies": {
-        "@types/jest": "^29.5.12",
+        "@types/jest": "^29.5.14",
         "jest": "^29.7.0",
         "jest-mock-extended": "^4.0.0",
         "prisma": "^6.16.2",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "zod": "^4.0.17"
   },
   "devDependencies": {
-    "@types/jest": "^29.5.12",
+    "@types/jest": "^29.5.14",
     "jest": "^29.7.0",
     "jest-mock-extended": "^4.0.0",
     "prisma": "^6.16.2",

--- a/src/services/shareLink.service.ts
+++ b/src/services/shareLink.service.ts
@@ -82,10 +82,6 @@ export const getShareLink = async ({ token }: GetShareLinkInput): Promise<GetSha
     if (shareLink.expiresAt && shareLink.expiresAt < new Date()) {
         throw new ServiceError(ServiceErrorCodes.SHARE_LINK_EXPIRED);
     }
-    /* 
-        const cacheKey = `share-link:${shareLink.id}`;
-        const cached = await redis.get<GetShareLinkResponse>(cacheKey);
-        if (cached) return cached; */
 
     const { project } = shareLink;
 
@@ -153,8 +149,9 @@ export const getShareLink = async ({ token }: GetShareLinkInput): Promise<GetSha
 
     };
 
-/*     await redis.set(cacheKey, data, { ex: 60 * 5 });
- */    return data;
+    const cacheKey = `share-links:${shareLink.projectId}`;
+    await redis.del(cacheKey);
+    return data;
 };
 
 // -------------------- Get list of share links --------------------


### PR DESCRIPTION
- Upgraded `@types/jest` from version 29.5.12 to 29.5.14 for improved type definitions.
- Refined caching logic in the `getShareLink` function by removing commented-out code and implementing cache deletion for share links, enhancing clarity and functionality.